### PR TITLE
Fixes invalid VS URLs to their correct valid values

### DIFF
--- a/spec/ns-obf/obf-allergy.txt
+++ b/spec/ns-obf/obf-allergy.txt
@@ -20,7 +20,7 @@ Property:          Criticality 0..1
 Property:          MostRecentOccurrenceTime 0..1
 Property:          AllergyIntoleranceReaction 0..*
                    // from http://hl7.org/fhir/ValueSet/allergy-verification-status
-                   // from http://hl7.org/fhir/us/core/ValueSet-us-core-substance.html if covered // DSTU 2 change different required value sets
+                   // from http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance if covered // DSTU 2 change different required value sets
                    Status 1..1
                    SubjectOfRecord 1..1
                    SubjectOfRecord only Patient
@@ -59,7 +59,7 @@ Property:          CommentOrDescription 0..1
 
 Element:           SubstanceCode
 Description:       "The substance triggering a particular allergy or intolerance reaction event. The substance may be the same as the substance cited in the AllergyIntolerance, but should be a specific substance rather than a class of substances, if known. For example, if the allergy intolerance DataValue substance is 'shellfish' the substance code for the reaction might be 'oyster'."
-Value:             concept from http://hl7.org/fhir/us/core/ValueSet-us-core-substance.html (extensible)/* Probably the most consistent way to define the absence (no known) allergy is to use an absence assertion, but this is not the way US Core has decided to go. Comments here are for reference only.
+Value:             concept from http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance (extensible)/* Probably the most consistent way to define the absence (no known) allergy is to use an absence assertion, but this is not the way US Core has decided to go. Comments here are for reference only.
 
 //				DataValue from NoKnownAllergyVS
 //				DataValue is SCT#716186003 "No known allergy (situation)"

--- a/spec/ns-obf/obf-entity.txt
+++ b/spec/ns-obf/obf-entity.txt
@@ -803,7 +803,7 @@ Property: AvailabilityExceptions 0..1
 Property: Endpoint 0..*
 Category from http://hl7.org/fhir/ValueSet/service-category
 Type from http://hl7.org/fhir/ValueSet/service-type
-Language from http://hl7.org/fhir/valueset-languages.html (preferred) 
+Language from http://hl7.org/fhir/ValueSet/languages (preferred)
 
 Element: SpecialtiesHandled
 Description: "Specialties handled by the HealthcareService Practice Setting Code Value Set (Preferred)"


### PR DESCRIPTION
This was causing a crash in the IG publisher when publishing STU3.

It was a pain to chase this down because the IG Publisher just crashed with no helpful output.  This also led me to submit a PR for the IG Publisher that avoids the crash.  See: https://github.com/HL7/fhir-ig-publisher/pull/42