### PR TITLE
Fixed as specified in FHIR-24514

### DIFF
--- a/spec/ig-mcode/ig-mcode-cp.txt
+++ b/spec/ig-mcode/ig-mcode-cp.txt
@@ -180,6 +180,8 @@ Namespace: onco.core
         BodyLocation.Code MS
         OccurrenceTimeOrPeriod MS
         TreatmentIntent MS
+        ReasonCode MS
+        CancerProcedureReasonReference MS
     GenomicsReport:
         Code MS  // Test name in Code.Text
         DiagnosticReportPerformer MS   // Laboratory name

--- a/spec/ig-mcode/ig-mcode-cp.txt
+++ b/spec/ig-mcode/ig-mcode-cp.txt
@@ -175,6 +175,8 @@ Namespace: onco.core
         Code MS   // req
         OccurrenceTimeOrPeriod MS  // req -- primarily because it is required in Argonaut Procedure profile
         TreatmentIntent MS  // req if known
+        ReasonCode MS
+        CancerProcedureReasonReference MS
     CancerRelatedRadiationProcedure:
         Code MS
         BodyLocation.Code MS


### PR DESCRIPTION
reasonCode and reasonReference elements changed to "MustSupport". It is important to be able to link the procedure to the specific cancer, especially when there is more than one tumor for a patient.